### PR TITLE
Reaction events now fire on uncached messages

### DIFF
--- a/cogs/votedelete.py
+++ b/cogs/votedelete.py
@@ -51,9 +51,11 @@ class VoteDelete(commands.Cog):
         return True
 
     @commands.Cog.listener()
-    async def on_reaction_add(self, reaction, user):
-        message = reaction.message
-        if self.checkDelete(reaction):
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+        channel = self.bot.get_channel(payload.channel_id)
+        message = await channel.fetch_message(payload.message_id)
+
+        if any(self.checkDelete(reaction) for reaction in message.reactions):
             try:
                 await message.delete()
             except discord.Forbidden:


### PR DESCRIPTION
The normal "on_reaction_add" and "on_reaction_remove" events are only fired on messages that are currently cached by the discord bot. 

This pull request uses the raw variants of these events, which are fired on any message, no matter how old they are.